### PR TITLE
[NOMERGE] build with amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3-amazoncorretto-21 as build
+FROM amd64/maven:3-amazoncorretto-21 as build
 COPY . /work/
 RUN cd /work; mvn package -DskipTests
 
-FROM amazoncorretto:21
+FROM amd64/maven:3-amazoncorretto-21
 COPY --from=build /work/kaldb/target/kaldb.jar /
 COPY --from=build /work/config/config.yaml /
 ENTRYPOINT [ "java", "--enable-preview", "-jar", "./kaldb.jar", "config.yaml" ]


### PR DESCRIPTION
###  Summary
If building on mac (arm), need to specify AMD64 base to create a compatible image for intel machines

